### PR TITLE
Address review comments from PR #25

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,3 +74,7 @@ This triggers:
 - **`release.yml`** — triggered by the new release, builds and attaches `peaqnext.zip` (HACS requirement via `hacs.json` `zip_release: true`)
 
 The zip must have files at the **root** (no `custom_components/peaqnext/` prefix), exclude test files and `__pycache__`.
+
+## Attribution
+
+Do not add "Co-Authored-By" lines in commit messages or "Generated with Claude Code" in PR descriptions.

--- a/custom_components/peaqnext/sensors/next_sensor.py
+++ b/custom_components/peaqnext/sensors/next_sensor.py
@@ -7,7 +7,6 @@ from custom_components.peaqnext.service.models.next_sensor.enums.calculate_by im
 from custom_components.peaqnext.service.models.next_sensor.enums.update_by import UpdateBy
 from ..const import DOMAIN, HUB
 from datetime import datetime, timedelta
-from homeassistant.util import dt as dt_util
 
 if TYPE_CHECKING:
     from custom_components.peaqnext.service.hub import Hub
@@ -166,7 +165,7 @@ class PeaqNextSensor(SensorEntity):
         if not self._check_hourmodel(model):
             return ""
 
-        now = dt_util.now()
+        now = datetime.now()
 
         if not self._relative_time:
             # Absolute time display - keep minute precision

--- a/custom_components/peaqnext/sensors/next_sensor.py
+++ b/custom_components/peaqnext/sensors/next_sensor.py
@@ -7,6 +7,7 @@ from custom_components.peaqnext.service.models.next_sensor.enums.calculate_by im
 from custom_components.peaqnext.service.models.next_sensor.enums.update_by import UpdateBy
 from ..const import DOMAIN, HUB
 from datetime import datetime, timedelta
+from homeassistant.util import dt as dt_util
 
 if TYPE_CHECKING:
     from custom_components.peaqnext.service.hub import Hub
@@ -165,7 +166,7 @@ class PeaqNextSensor(SensorEntity):
         if not self._check_hourmodel(model):
             return ""
 
-        now = datetime.now()
+        now = dt_util.now()
 
         if not self._relative_time:
             # Absolute time display - keep minute precision

--- a/custom_components/peaqnext/service/segments.py
+++ b/custom_components/peaqnext/service/segments.py
@@ -42,7 +42,7 @@ def calculate_consumption_per_hour(
                 intret = 0
             j += 1
     except Exception as e:
-        _LOGGER.error(f"Error calculating consumption per hour: {e}")
+        _LOGGER.exception("Error calculating consumption per hour")
     return ret
 
 

--- a/custom_components/peaqnext/service/segments.py
+++ b/custom_components/peaqnext/service/segments.py
@@ -41,7 +41,7 @@ def calculate_consumption_per_hour(
                 ret.append(round(intret, 1))
                 intret = 0
             j += 1
-    except Exception as e:
+    except Exception:
         _LOGGER.exception("Error calculating consumption per hour")
     return ret
 

--- a/custom_components/peaqnext/test/test_nextsensor.py
+++ b/custom_components/peaqnext/test/test_nextsensor.py
@@ -367,6 +367,17 @@ async def test_price_change_per_minute():
     assert len(s.all_sequences) > 0
 
 
+def _spanned_hours(dt_start: datetime, dt_end: datetime) -> set[int]:
+    """Return the set of hours (0-23) spanned by a time interval, handling midnight crossover."""
+    hours = set()
+    current = dt_start.replace(minute=0, second=0, microsecond=0)
+    end = dt_end.replace(minute=0, second=0, microsecond=0)
+    while current <= end:
+        hours.add(current.hour)
+        current += timedelta(hours=1)
+    return hours
+
+
 @pytest.mark.asyncio
 async def test_blocked_interval_spans_middle_hours():
     """Verify that intervals spanning through a blocked hour are filtered out, not just start/end."""
@@ -379,8 +390,8 @@ async def test_blocked_interval_spans_middle_hours():
     s.dt_model.set_minute(0)
     await s.async_update_sensor((_p.P230729BE, []), use_cent=False)
     for seq in s.all_sequences:
-        spanned_hours = set(range(seq.dt_start.hour, seq.dt_end.hour + 1))
-        assert 10 not in spanned_hours, f"Sequence {seq.dt_start}-{seq.dt_end} spans blocked hour 10"
+        hours = _spanned_hours(seq.dt_start, seq.dt_end)
+        assert 10 not in hours, f"Sequence {seq.dt_start}-{seq.dt_end} spans blocked hour 10"
 
 
 @pytest.mark.asyncio
@@ -395,8 +406,40 @@ async def test_blocked_interval_spans_middle_hours_end():
     s.dt_model.set_minute(0)
     await s.async_update_sensor((_p.P230729BE, []), use_cent=False)
     for seq in s.all_sequences:
-        spanned_hours = set(range(seq.dt_start.hour, seq.dt_end.hour + 1))
-        assert 15 not in spanned_hours, f"Sequence {seq.dt_start}-{seq.dt_end} spans blocked hour 15"
+        hours = _spanned_hours(seq.dt_start, seq.dt_end)
+        assert 15 not in hours, f"Sequence {seq.dt_start}-{seq.dt_end} spans blocked hour 15"
+
+
+@pytest.mark.asyncio
+async def test_blocked_interval_crossing_midnight_start():
+    """Verify that blocked hours are respected for intervals that cross midnight (non_hours_start)."""
+    nh_start = [0]  # Block midnight hour
+    s = NextSensor(
+        consumption_type=ConsumptionType.Flat, name="test", hass_entity_id="sensor.test",
+        total_duration_in_minutes=180, total_consumption_in_kwh=10, non_hours_start=nh_start
+    )
+    s.dt_model.set_hour(20)
+    s.dt_model.set_minute(0)
+    await s.async_update_sensor((_p.P230729BE, _p.P230731), use_cent=False)
+    for seq in s.all_sequences:
+        hours = _spanned_hours(seq.dt_start, seq.dt_end)
+        assert 0 not in hours, f"Sequence {seq.dt_start}-{seq.dt_end} spans blocked hour 0"
+
+
+@pytest.mark.asyncio
+async def test_blocked_interval_crossing_midnight_end():
+    """Verify that blocked hours are respected for intervals that cross midnight (non_hours_end)."""
+    nh_end = [1]  # Block hour 1
+    s = NextSensor(
+        consumption_type=ConsumptionType.Flat, name="test", hass_entity_id="sensor.test",
+        total_duration_in_minutes=180, total_consumption_in_kwh=10, non_hours_end=nh_end
+    )
+    s.dt_model.set_hour(20)
+    s.dt_model.set_minute(0)
+    await s.async_update_sensor((_p.P230729BE, _p.P230731), use_cent=False)
+    for seq in s.all_sequences:
+        hours = _spanned_hours(seq.dt_start, seq.dt_end)
+        assert 1 not in hours, f"Sequence {seq.dt_start}-{seq.dt_end} spans blocked hour 1"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- **segments.py**: Use `_LOGGER.exception()` instead of `_LOGGER.error()` to preserve stack traces for debugging
- **next_sensor.py**: Use `dt_util.now()` instead of `datetime.now()` for timezone-aware datetime in HA context
- **Tests**: Fix `spanned_hours` calculation to handle midnight-crossing intervals using datetime iteration instead of naive `range(start.hour, end.hour + 1)`
- **Tests**: Add dedicated tests for blocked intervals that cross midnight (`non_hours_start` and `non_hours_end`)

Addresses post-merge review comments on #25.

## Test plan
- [x] All 32 existing tests pass
- [x] New midnight-crossing tests verify blocked hours are respected across day boundaries