### PR TITLE
Fix Nordpool entity discovery for newer Home Assistant

### DIFF
--- a/custom_components/peaqnext/service/hub.py
+++ b/custom_components/peaqnext/service/hub.py
@@ -26,11 +26,16 @@ class Hub:
         self.spotprice: ISpotPrice = SpotPriceFactory.create(self, test)
         self.latest_spotprice_update = 0
         if not test:
-            async_track_state_change_event(
-                self.state_machine,
-                [self.spotprice.entity],
-                self._async_on_change,
-            )
+            if self.spotprice.entity:
+                async_track_state_change_event(
+                    self.state_machine,
+                    [self.spotprice.entity],
+                    self._async_on_change,
+                )
+            else:
+                _LOGGER.error(
+                    "No Spotprice entity available; state-change tracking disabled."
+                )
 
     async def async_setup(self, sensors: list[NextSensor]) -> None:
         self.sensors.extend(sensors)

--- a/custom_components/peaqnext/service/spotprice/nordpool.py
+++ b/custom_components/peaqnext/service/spotprice/nordpool.py
@@ -3,7 +3,7 @@ from custom_components.peaqnext.service.spotprice.spotprice_dto import NordpoolD
 from custom_components.peaqnext.service.spotprice.const import NORDPOOL
 import logging
 import asyncio
-import homeassistant.helpers.template as template
+from homeassistant.helpers.entity import entity_sources
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -22,15 +22,19 @@ class NordPoolUpdater(ISpotPrice):
 
     def setup(self):
         try:
-            entities = template.integration_entities(self.state_machine, self._source)
-            _LOGGER.debug(f"Found {list(entities)} Spotprice entities.")
-            if len(list(entities)) < 1:
+            entities = [
+                entity_id
+                for entity_id, info in entity_sources(self.state_machine).items()
+                if info.get("domain") == self._source
+            ]
+            _LOGGER.debug(f"Found {entities} Spotprice entities.")
+            if len(entities) < 1:
                 raise Exception("no entities found for Spotprice.")
-            if len(list(entities)) == 1:
+            if len(entities) == 1:
                 self._setup_set_entity(entities[0])
             else:
                 _found: bool = False
-                for e in list(entities):
+                for e in entities:
                     if self._test_sensor(e):
                         _found = True
                         self._setup_set_entity(e)

--- a/custom_components/peaqnext/service/spotprice/spotprice_factory.py
+++ b/custom_components/peaqnext/service/spotprice/spotprice_factory.py
@@ -1,5 +1,4 @@
 from custom_components.peaqnext.service.spotprice.const import *
-import homeassistant.helpers.template as template
 from custom_components.peaqnext.service.spotprice.ispotprice import ISpotPrice
 from custom_components.peaqnext.service.spotprice.nordpool import NordPoolUpdater
 from custom_components.peaqnext.service.spotprice.energidataservice import EnergiDataServiceUpdater


### PR DESCRIPTION
`homeassistant.helpers.template` became a package in recent HA versions
and `integration_entities` is no longer a module-level function (it's a
Jinja method on ConfigEntryExtension). The old call therefore raised
`AttributeError`, left the spotprice entity unset, and crashed the Hub
when `async_track_state_change_event` received `[None]`.

Use `homeassistant.helpers.entity.entity_sources` directly to look up
entities by integration domain — this is the same fallback logic the
original `integration_entities` helper used internally. Also guard the
Hub against a missing spotprice entity so a misconfigured environment
logs an error instead of crashing the integration setup.

Fixes elden1337/hass-peaqnext#34