### PR TITLE
Release v0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.6.3
+
+### Fix: Nordpool entity discovery on newer Home Assistant
+
+`homeassistant.helpers.template` was restructured into a package in recent Home Assistant versions and `integration_entities` is no longer a module-level function (it now lives as a Jinja method on `ConfigEntryExtension`). The old call raised `AttributeError`, left the spotprice entity unset, and crashed the Hub when `async_track_state_change_event` received `[None]`.
+
+- Look up entities via `homeassistant.helpers.entity.entity_sources` directly — the same fallback logic the original helper used internally.
+- Guard the Hub against a missing spotprice entity so a misconfigured environment logs an error instead of crashing setup.
+
+Fixes elden1337/hass-peaqnext#34.
+
 ## v0.6.2
 
 ### Fix: Incorrect price mapping for sub-hourly Nordpool data

--- a/custom_components/peaqnext/manifest.json
+++ b/custom_components/peaqnext/manifest.json
@@ -14,5 +14,5 @@
     "integration_type": "hub",
     "iot_class": "calculated",
     "issue_tracker": "https://github.com/nord-/hass-peaqnext/issues",
-    "version": "0.6.2"
+    "version": "0.6.3"
 }


### PR DESCRIPTION
Bumps `manifest.json` to `0.6.3` and adds the matching `CHANGELOG.md` entry to ship the Nordpool entity discovery fix (#28).

Merging triggers:
- `auto-release.yml` — creates GitHub Release **v0.6.3** with notes from CHANGELOG.
- `release.yml` — builds and attaches `peaqnext.zip` for HACS.

Fixes elden1337/hass-peaqnext#34.